### PR TITLE
Lower minimum docker-compose version req

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 #
 # Metrics services -- provides a web GUI to monitor Lighthouse nodes.
 #
-version: "3.7"
+version: "3.3"
 
 services:
     prometheus:


### PR DESCRIPTION
Version 3.7 of the config was too cutting edge for my Ubuntu machine, which only has `docker-compose` 1.21.1, supporting up to file-format v3.6 (as per [release notes](https://github.com/docker/compose/releases/tag/1.21.0)).