### PR TITLE
Add validator client metrics port 5064 to scrape-targets

### DIFF
--- a/scrape-targets/scrape-targets.json
+++ b/scrape-targets/scrape-targets.json
@@ -4,7 +4,8 @@
       "job": "nodes"
     },
     "targets": [
-      "localhost:5054"
+      "localhost:5054",
+      "localhost:5064"
     ]
   }
 ]


### PR DESCRIPTION
Adds support for validator metrics from sigp/lighthouse#1954