### PR TITLE
Accurately Describe Metrics Source in Dashboard

### DIFF
--- a/dashboards/ValidatorClient.json
+++ b/dashboards/ValidatorClient.json
@@ -35,7 +35,7 @@
       "id": 46,
       "links": [],
       "options": {
-        "content": "\n# Lighthouse Metrics\n\nMetrics collected from a Lighthouse Beacon Node.\n\n\n\n",
+        "content": "\n# Lighthouse Metrics\n\nMetrics collected from a Lighthouse Validator Client.\n\n\n\n",
         "mode": "markdown"
       },
       "pluginVersion": "7.3.4",


### PR DESCRIPTION
Metrics in this dashboard are collected from the Validator Client - not the Beacon Node.