### PR TITLE
Bug in local attestor count

### DIFF
--- a/dashboards/ValidatorClient.json
+++ b/dashboards/ValidatorClient.json
@@ -199,7 +199,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "vc_beacon_block_proposer_count",
+          "expr": "vc_beacon_attester_count",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,


### PR DESCRIPTION
Thank you for your great dashboard. I think there is a bug in the query, the proposer count is actually repeated in the attestor count.

Have updated to the correct query to find the local attestor count.