### PR TITLE
Update variable name per Lighthouse v2.1.0

### DIFF
--- a/dashboards/NetworkPropagation.json
+++ b/dashboards/NetworkPropagation.json
@@ -2804,7 +2804,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "libp2p_peer_connected_peers_total",
+          "expr": "libp2p_peers",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"

--- a/dashboards/Summary.json
+++ b/dashboards/Summary.json
@@ -2395,7 +2395,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "libp2p_peer_connected_peers_total",
+          "expr": "libp2p_peers",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"


### PR DESCRIPTION
`libp2p_peer_connected_peers_total` was renamed to `libp2p_peers`.