### PR TITLE
Update libp2p metrics in Network dashboard (Lighthouse 4.6.0)

### DIFF
--- a/dashboards/Network.json
+++ b/dashboards/Network.json
@@ -602,7 +602,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "rate(libp2p_total_bandwidth{instance=~\"$Instance\"}[$__rate_interval])",
+          "expr": "sum(rate(libp2p_bandwidth_bytes_total{instance=~\"$Instance\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "{{instance}}",
           "refId": "A"
@@ -697,7 +697,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "rate(libp2p_inbound_bytes{instance=~\"$Instance\"}[1m])",
+          "expr": "sum(rate(libp2p_bandwidth_bytes_total{instance=~\"$Instance\",direction=\"Inbound\"}[1m]))",
           "interval": "",
           "legendFormat": "bytes/s",
           "refId": "A"
@@ -792,7 +792,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "rate(libp2p_outbound_bytes{instance=~\"$Instance\"}[$__rate_interval])",
+          "expr": "sum(rate(libp2p_bandwidth_bytes_total{instance=~\"$Instance\",direction=\"Outbound\"}[1m]))",
           "interval": "",
           "legendFormat": "bytes/s",
           "refId": "A"
@@ -888,7 +888,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "rate(libp2p_total_bandwidth{instance=~\"$Instance\"}[$__rate_interval]) + rate(discovery_sent_bytes{instance=~\"$Instance\"}[$__rate_interval]) + rate(discovery_recv_bytes{instance=~\"$Instance\"}[$__rate_interval])",
+          "expr": "sum(rate(libp2p_bandwidth_bytes_total{instance=~\"$Instance\"}[$__rate_interval])) + sum(rate(discovery_sent_bytes{instance=~\"$Instance\"}[$__rate_interval])) + sum(rate(discovery_recv_bytes{instance=~\"$Instance\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "{{instance}} bytes/s",
           "refId": "A"

--- a/dashboards/NetworkLatest.json
+++ b/dashboards/NetworkLatest.json
@@ -612,7 +612,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "exemplar": true,
-              "expr": "rate(libp2p_total_bandwidth{instance=~\"$Instance\"}[$__rate_interval])",
+              "expr": "sum(rate(libp2p_bandwidth_bytes_total{instance=~\"$Instance\"}[$__rate_interval]))",
               "interval": "",
               "legendFormat": "{{instance}}",
               "refId": "A"
@@ -706,7 +706,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "exemplar": true,
-              "expr": "rate(libp2p_inbound_bytes{instance=~\"$Instance\"}[1m])",
+              "expr": "sum(rate(libp2p_bandwidth_bytes_total{instance=~\"$Instance\",direction=\"Inbound\"}[1m]))",
               "interval": "",
               "legendFormat": "bytes/s",
               "refId": "A"
@@ -800,7 +800,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "exemplar": true,
-              "expr": "rate(libp2p_outbound_bytes{instance=~\"$Instance\"}[$__rate_interval])",
+              "expr": "sum(rate(libp2p_bandwidth_bytes_total{instance=~\"$Instance\",direction=\"Outbound\"}[1m]))",
               "interval": "",
               "legendFormat": "bytes/s",
               "refId": "A"
@@ -1036,7 +1036,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "exemplar": true,
-              "expr": "rate(libp2p_total_bandwidth{instance=~\"$Instance\"}[$__rate_interval]) + rate(discovery_sent_bytes{instance=~\"$Instance\"}[$__rate_interval]) + rate(discovery_recv_bytes{instance=~\"$Instance\"}[$__rate_interval])",
+              "expr": "sum(rate(libp2p_bandwidth_bytes_total{instance=~\"$Instance\"}[$__rate_interval])) + sum(rate(discovery_sent_bytes{instance=~\"$Instance\"}[$__rate_interval])) + sum(rate(discovery_recv_bytes{instance=~\"$Instance\"}[$__rate_interval]))",
               "interval": "",
               "legendFormat": "{{instance}} bytes/s",
               "refId": "A"

--- a/dashboards/Summary.json
+++ b/dashboards/Summary.json
@@ -2800,7 +2800,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(libp2p_total_bandwidth[1m])",
+          "expr": "sum(rate(libp2p_bandwidth_bytes_total[1m]))",
           "legendFormat": "bytes/s",
           "refId": "A"
         }
@@ -2892,7 +2892,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(libp2p_inbound_bytes[1m])",
+          "expr": "sum(rate(libp2p_bandwidth_bytes_total{direction=\"Inbound\"}[1m]))",
           "legendFormat": "bytes/s",
           "refId": "A"
         }
@@ -2984,7 +2984,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(libp2p_outbound_bytes[1m])",
+          "expr": "sum(rate(libp2p_bandwidth_bytes_total{direction=\"Outbound\"}[1m]))",
           "legendFormat": "bytes/s",
           "refId": "A"
         }


### PR DESCRIPTION
The libp2p metrics have been updated in 4.6.0 as part of the libp2p version upgrade. 