### PR TITLE
Remove uid in Attestation Simulator

### DIFF
--- a/dashboards/AttestationSimulator.json
+++ b/dashboards/AttestationSimulator.json
@@ -30,8 +30,7 @@
   "panels": [
     {
       "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "type": "prometheus"
       },
       "description": "",
       "fieldConfig": {
@@ -110,8 +109,7 @@
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "type": "prometheus"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -159,8 +157,7 @@
     },
     {
       "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
+        "type": "prometheus"
       },
       "description": "",
       "fieldConfig": {
@@ -239,8 +236,7 @@
       "targets": [
         {
           "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
+            "type": "prometheus"
           },
           "disableTextWrap": false,
           "editorMode": "code",
@@ -294,8 +290,7 @@
     "list": [
       {
         "datasource": {
-          "type": "prometheus",
-          "uid": "PBFA97CFB590B2093"
+          "type": "prometheus"
         },
         "filters": [],
         "hide": 0,


### PR DESCRIPTION
When I add the [attestation simulator dashboard](https://github.com/sigp/lighthouse-metrics/blob/master/dashboards/AttestationSimulator.json) I encountered an error:

![metrics](https://github.com/sigp/lighthouse-blog/assets/44791194/c935ad25-e0c6-48cd-b8e9-1a9a5d943d2b)

which points to this: 

https://github.com/sigp/lighthouse-metrics/blob/27b511b2067b16a5ec5ec9d40dca641daa8f1f1a/dashboards/AttestationSimulator.json#L34

The `uid` line does not appear in other dashboards so I delete those lines and the dashboard can now display properly

